### PR TITLE
ws_type: fix DanmuMessage construct

### DIFF
--- a/src/ws_type/dannmu_msg.rs
+++ b/src/ws_type/dannmu_msg.rs
@@ -37,7 +37,7 @@ impl DanmuMessage {
 
         let msg = info
             .get(1)
-            .and_then(|x| x.as_u64())
+            .and_then(|x| x.as_str())
             .ok_or_else(|| LiveMessageError::DanmuMessageError(owned(ctx)))?
             .to_string();
 


### PR DESCRIPTION
msg 的提取有问题，导致使用 ws_socket_object 时无法获取弹幕信息